### PR TITLE
Bugfix: Expect 201 upon a successful ArticleAPI.create call

### DIFF
--- a/pages/editor/new.tsx
+++ b/pages/editor/new.tsx
@@ -41,7 +41,7 @@ const PublishArticleEditor = () => {
 
     setLoading(false);
 
-    if (status !== 200) {
+    if (status !== 201) {
       setErrors(data.errors);
     }
 


### PR DESCRIPTION
201 is the standard HTTP status response code when successfully creating a resource. Backend frameworks like NestJS return 201 when responding to POST requests (https://docs.nestjs.com/controllers#status-code).

*Bug reproduction*

I came across this issue with vanilla installations of this repo (from commit be9ef569bc395975d98c1973fac23ba9277797e7) as frontend, and of the [NestJS+MikroORM repo](https://github.com/mikro-orm/nestjs-realworld-example-app) (commit 827cee98b3b6078d26860b5251b3587e29de6484) as backend. 

Then, simply create an Article using the UI to land in the _if clause_ in the modified code, which triggers `setErrors` without an error having occurred. 

*Fix*
Backend reasonably fires 201 upon success, so expect a 201.